### PR TITLE
adding missing attribute (type) in audio tag

### DIFF
--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -238,7 +238,7 @@ html_elements! {
     /// The `<aside>` HTML element represents a portion of a document whose content is only indirectly related to the document's main content. Asides are frequently presented as sidebars or call-out boxes.
     aside HtmlElement [] true,
     /// The `<audio>` HTML element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the source element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.
-    audio HtmlAudioElement [autoplay, controls, crossorigin, r#loop, muted, preload, src] true,
+    audio HtmlAudioElement [autoplay, controls, crossorigin, r#loop, muted, preload, src, r#type] true,
     /// The `<b>` HTML element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use `<b>` for styling text; instead, you should use the CSS font-weight property to create boldface text, or the strong element to indicate that text is of special importance.
     b HtmlElement [] true,
     /// The `<bdi>` HTML element tells the browser's bidirectional algorithm to treat the text it contains in isolation from its surrounding text. It's particularly useful when a website dynamically inserts some text and doesn't know the directionality of the text being inserted.


### PR DESCRIPTION
Someone in Discord found this problem:
![imagen](https://github.com/user-attachments/assets/4df9e09c-b898-4c2f-96cc-864680531964)
